### PR TITLE
Select2 enhancements (nectry issue #71)

### DIFF
--- a/examples/selector.ur
+++ b/examples/selector.ur
@@ -1,0 +1,46 @@
+val options = <xml>
+    <coption value="a">Alpha</coption>
+    <coption value="b" selected={True}>Beta</coption>
+    <coption value="c">Gamma</coption>
+</xml>
+
+val pg_select2 = <xml>
+    <body>
+        <active code={
+            w <- Select2.createSingle options;
+            return <xml>
+                {Select2.renderSingle w}
+                <dyn signal={
+                    curr <- Select2.selectedSingle w;
+                    return <xml>
+                        <active code={
+                            return <xml><p style="color: red">{[curr]}</p></xml>
+                        }/>
+                       </xml>}/>
+                </xml>}/>
+
+    </body>
+</xml>
+
+val pg_select2_multi : page = <xml>
+    <body>
+        <active code={
+            w <- Select2.createMulti options;
+            return <xml>
+                {Select2.renderMulti w}
+                <dyn signal={
+                    curr <- Select2.selectedMulti w;
+                    return <xml>
+                        <active code={
+                            return <xml><ul>{List.mapX (fn i =>
+                            <xml><li style="color: red">{[i]}</li></xml>) curr}</ul></xml>
+                        }/>
+                       </xml>}/>
+                </xml>}/>
+
+    </body>
+</xml>
+
+
+
+fun main () = return pg_select2

--- a/examples/selector.ur
+++ b/examples/selector.ur
@@ -19,6 +19,12 @@ val pg_select2 = <xml>
                             return <xml><p style="color: red">{[curr]}</p></xml>
                         }/>
                        </xml>}/>
+                <button
+                  onclick={fn _ => Select2.setSingleSelection w "a"}>
+                  Select Alpha</button>
+                <button
+                  onclick={fn _ => Select2.setSingleSelection' w 2}>
+                  Select 3</button>
                 </xml>}/>
 
     </body>

--- a/examples/selector.ur
+++ b/examples/selector.ur
@@ -1,5 +1,3 @@
-val css = bless "https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css"
-
 val options = <xml>
     <coption value="a">Alpha</coption>
     <coption value="b" selected={True}>Beta</coption>

--- a/examples/selector.ur
+++ b/examples/selector.ur
@@ -1,8 +1,7 @@
-val options = <xml>
-    <coption value="a">Alpha</coption>
-    <coption value="b" selected={True}>Beta</coption>
-    <coption value="c">Gamma</coption>
-</xml>
+val options =
+    ("a", "Alpha") ::
+    ("b", "Beta") ::
+    ("c", "Gamma") :: []
 
 val pg_select2 = <xml>
     <head>
@@ -10,11 +9,11 @@ val pg_select2 = <xml>
     </head>
     <body>
         <active code={
-            w <- Select2.createSingle options;
+            w <- Select2.createSingle options (Some 1);
             return <xml>
-                {Select2.renderSingle w}
+                {Select2.render w}
                 <dyn signal={
-                    curr <- Select2.selectedSingle w;
+                    curr <- Select2.selected w;
                     return <xml>
                         <active code={
                             return <xml><p style="color: red">{[curr]}</p></xml>
@@ -25,14 +24,14 @@ val pg_select2 = <xml>
     </body>
 </xml>
 
-val pg_select2_multi : page = <xml>
+(* val pg_select2_multi : page = <xml>
     <body>
         <active code={
             w <- Select2.createMulti options;
             return <xml>
-                {Select2.renderMulti w}
+                {Select2.render w}
                 <dyn signal={
-                    curr <- Select2.selectedMulti w;
+                    curr <- Select2.selected w;
                     return <xml>
                         <active code={
                             return <xml><ul>{List.mapX (fn i =>
@@ -42,7 +41,7 @@ val pg_select2_multi : page = <xml>
                 </xml>}/>
 
     </body>
-</xml>
+</xml> *)
 
 
 

--- a/examples/selector.ur
+++ b/examples/selector.ur
@@ -1,3 +1,5 @@
+val css = bless "https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css"
+
 val options = <xml>
     <coption value="a">Alpha</coption>
     <coption value="b" selected={True}>Beta</coption>
@@ -5,6 +7,9 @@ val options = <xml>
 </xml>
 
 val pg_select2 = <xml>
+    <head>
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet"/>
+    </head>
     <body>
         <active code={
             w <- Select2.createSingle options;

--- a/examples/selector.urp
+++ b/examples/selector.urp
@@ -1,0 +1,6 @@
+library ../select2
+script https://code.jquery.com/jquery-3.6.0.min.js
+script https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js
+
+$/list
+selector

--- a/examples/selector.urp
+++ b/examples/selector.urp
@@ -1,6 +1,7 @@
 library ../select2
 script https://code.jquery.com/jquery-3.6.0.min.js
 script https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js
+allow url https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css
 
 $/list
 selector

--- a/examples/selector.urs
+++ b/examples/selector.urs
@@ -1,0 +1,2 @@
+val main : unit -> transaction page
+val pg_select2 : page

--- a/examples/selector.urs
+++ b/examples/selector.urs
@@ -1,2 +1,1 @@
 val main : unit -> transaction page
-val pg_select2 : page

--- a/select2.ur
+++ b/select2.ur
@@ -1,47 +1,75 @@
-type single = {Options : xml [Cselect, Body] [] [],
-              Selected : source string}
-type multi = {Options : xml [Cselect, Body] [] [],
-             Selected : source (list string)}
+(* selector - describes the state of the select2 component.
+ *
+ * Parameterized by a type t corresponding to the underlying values, and by a
+ *   type -> type k corresponding to how t is wrapped - as a list or as an
+ *   an option, corresponding to multi and single selectors.
+ *
+ * This is necessary to get the functions to be nicely generic.
+ *)
+type selector k t =
+  {Options : xml [Cselect, Body] [] [],
+   Values : list t,
+   Selected : source (k int),
+   Multi : bool}
 
-fun createMulti options =
-    s <- source [];
-    return {Options = options, Selected = s}
+(* Typeclasses describing how to unwrap the lists from the Select2 FFI into
+ * lists (in the case of multi) and options (in the case of single).
+ * 
+ * This is necessary to get the functions to be nicely generic.
+ *)
+con singleOrMulti k = list string -> k int
+fun singleOrMulti_option selections =
+  case selections of
+    (x :: _) => Some (readError x)
+  | [] => None
+fun singleOrMulti_list selections = List.mp readError selections
 
-fun createSingle options =
-    s <- source "";
-    return {Options = options, Selected = s}
+fun createOptions [t ::: Type] (options : list (t * string * bool)) : xml [Cselect, Body] [] [] =
+    List.mapXi (fn i (_, x, s) => <xml><coption value={show i} selected={s}>{[x]}</coption></xml>) options
 
-fun renderMulti self = <xml>
+(* Takes a list of options, each one a tuple:
+ *   (value : t, display : string, selected : bool)
+ *)
+fun createMulti [t] options =
+    let
+      val selection = List.foldr (fn (_, _, s) (i, xs) => if s then (i+1, i :: xs) else (i+1, xs)) (0, []) options
+    in
+      s <- source selection.2;
+      return {Options = createOptions options, Values = List.mp (fn x => x.1) options, Selected = s, Multi = True}
+    end
+
+(* Takes a list of options, each one a tuple:
+ *   (value : t, display : string)
+ * and an option int indexing the list to identify a pre-selected item or
+ * lack thereof. If the integer is out of bounds, it is rounded to the
+ * beginning or end of the list, so this is safe.
+ *)
+fun createSingle [t] options selection =
+    let
+      val selection' = Option.mp (fn x =>  min (max x 0) (List.length options - 1)) selection   (* Protect against index-out-of-bounds. *)
+      val options' = List.mapi (fn i (v, x) => (v, x, Some i = selection')) options
+    in
+      s <- source selection';
+      return {Options = createOptions options', Values = List.mp (fn x => x.1) options, Selected = s, Multi = False}
+    end
+
+fun render [t] [k] (readFromList : singleOrMulti k) self = <xml>
   <active code={id <- fresh;
                 return <xml>
                   <span onclick={fn _ => stopPropagation}>
-                    <cselect id={id} multiple={True}>
+                    <cselect id={id} multiple={self.Multi}>
                       {self.Options}
                     </cselect>
                   </span>
-                  <active code={Select2Ffi.replace id (set self.Selected);
+                  <active code={Select2Ffi.replace id (fn x => set self.Selected (readFromList x));
                                 return <xml></xml>}/>
                 </xml>}/>
 </xml>
 
-fun renderSingle self = <xml>
-  <active code={id <- fresh;
-                return <xml>
-                  <span onclick={fn _ => stopPropagation}>
-                    <cselect id={id} multiple={False}>
-                      {self.Options}
-                    </cselect>
-                  </span>
-                  <active code={Select2Ffi.replace id
-                    (fn x =>
-                        set self.Selected
-                        (case x of
-                          (z :: _) => z
-                        | [] => error <xml>Source cannot be empty list</xml>));
-                                return <xml></xml>}/>
-                </xml>}/>
-</xml>
+fun lookupValue [t ::: Type] (values : list t) (i : int) : t =
+  (* This computation cannot fail since the `i` argument is guaranteed to be in-bounds. *)
+  Option.unsafeGet (List.nth values i)
 
-fun selectedMulti self = signal self.Selected
-
-fun selectedSingle self = signal self.Selected
+fun selected [t] [k] (_ : monad k) self =
+  s <- signal self.Selected;
+  return (Monad.mp (lookupValue self.Values) s)

--- a/select2.ur
+++ b/select2.ur
@@ -1,20 +1,21 @@
-type t = {Multi : bool,
-          Options : xml [Cselect, Body] [] [],
-          Selected : source (list string)}
+type single = {Options : xml [Cselect, Body] [] [],
+              Selected : source string}
+type multi = {Options : xml [Cselect, Body] [] [],
+             Selected : source (list string)}
 
-fun create options =
+fun createMulti options =
     s <- source [];
-    return {Multi = True, Options = options, Selected = s}
+    return {Options = options, Selected = s}
 
 fun createSingle options =
-    s <- source [];
-    return {Multi = False, Options = options, Selected = s}
+    s <- source "";
+    return {Options = options, Selected = s}
 
-fun render self = <xml>
+fun renderMulti self = <xml>
   <active code={id <- fresh;
                 return <xml>
                   <span onclick={fn _ => stopPropagation}>
-                    <cselect id={id} multiple={self.Multi}>
+                    <cselect id={id} multiple={True}>
                       {self.Options}
                     </cselect>
                   </span>
@@ -23,4 +24,25 @@ fun render self = <xml>
                 </xml>}/>
 </xml>
 
-fun selected self = signal self.Selected
+fun renderSingle self = <xml>
+  <active code={id <- fresh;
+                return <xml>
+                  <span onclick={fn _ => stopPropagation}>
+                    <cselect id={id} multiple={False}>
+                      {self.Options}
+                    </cselect>
+                  </span>
+                  <active code={Select2Ffi.replace id
+                    (fn x =>
+                        set self.Selected
+                        ((fn y => case y of
+                            (z :: _) => z
+                          | [] => error <xml>Source cannot be empty list</xml>
+                        ) x));
+                                return <xml></xml>}/>
+                </xml>}/>
+</xml>
+
+fun selectedMulti self = signal self.Selected
+
+fun selectedSingle self = signal self.Selected

--- a/select2.ur
+++ b/select2.ur
@@ -37,9 +37,6 @@ val listLike_ident = {
   ToList = fn [t] x => x :: []
 }
 
-fun fromList [k ::: Type -> Type] [t ::: Type] (l : listLike k) (lst : list t) : k t =
-  l.FromList lst
-
 (* We shouldn't have to write this - there should be a generic "mappable" or
 "functor" with instances for option and list. *)
 con mappable k = t ::: Type -> u ::: Type -> (t -> u) -> k t -> k u
@@ -79,14 +76,14 @@ fun createSingle [t] options selection =
 fun createRequiredSingle [t] options selection =
     let
       val selection' = min (max selection 0) (List.length options - 1)
-      val options' = List.mapi (fn i (v, x) => (v, x, Some i = selection')) options
+      val options' = List.mapi (fn i (v, x) => (v, x, i = selection')) options
     in
       s <- source selection';
       return {Options = createOptions options', Values = List.mp (fn x => x.1) options, Selected = s, Multi = False}
     end
 
 
-fun render [t] [k] (_ : listLike k) (mp : mappable k) self = <xml>
+fun render [t] [k] (lstLike : listLike k) (mp : mappable k) self = <xml>
   <active code={id <- fresh;
                 return <xml>
                   <span onclick={fn _ => stopPropagation}>
@@ -96,7 +93,7 @@ fun render [t] [k] (_ : listLike k) (mp : mappable k) self = <xml>
                   </span>
                   <active code={
                     Select2Ffi.replace id
-                      (fn x => set self.Selected (mp readError (fromList x)));
+                      (fn x => set self.Selected (mp readError (lstLike.FromList [string] x)));
                     return <xml></xml>}/>
                 </xml>}/>
 </xml>

--- a/select2.ur
+++ b/select2.ur
@@ -35,10 +35,9 @@ fun renderSingle self = <xml>
                   <active code={Select2Ffi.replace id
                     (fn x =>
                         set self.Selected
-                        ((fn y => case y of
-                            (z :: _) => z
-                          | [] => error <xml>Source cannot be empty list</xml>
-                        ) x));
+                        (case x of
+                          (z :: _) => z
+                        | [] => error <xml>Source cannot be empty list</xml>));
                                 return <xml></xml>}/>
                 </xml>}/>
 </xml>

--- a/select2.ur
+++ b/select2.ur
@@ -12,22 +12,40 @@ type selector k t =
    Selected : source (k int),
    Multi : bool}
 
-(* Typeclasses describing how to unwrap the lists from the Select2 FFI into
- * lists (in the case of multi) and options (in the case of single).
- * 
- * This is necessary to get the functions to be nicely generic.
+(* Typeclass describing how a type is like a list, because it can go to or from
+ * a list.  `FromList . ToList` should be the identity.
+ *
+ * Should be upstreamed
  *)
-con singleOrMulti k = list string -> k int
-fun singleOrMulti_option selections =
-  case selections of
-    (x :: _) => Some (readError x)
-  | [] => None
-fun singleOrMulti_list selections = List.mp readError selections
+con listLike k = {
+  FromList : t ::: Type -> list t -> k t,
+  ToList : t ::: Type -> k t -> list t
+}
 
-(* We shouldn't have to write this - there should be a generic "mappable" or "functor" with instances for option and list. *)
+val listLike_option = {
+  FromList = fn [t] lst => case lst of [] => None | x :: _ => Some x,
+  ToList = fn [t] o => case o of None => [] | Some x => x :: []
+}
+val listLike_list = {
+  FromList = fn [t] lst => lst,
+  ToList = fn [t] lst => lst
+}
+val listLike_ident = {
+  FromList = fn [t] lst => case lst of
+      [] => error <xml>listLike is partial for identity!</xml>
+    | x :: _ => x,
+  ToList = fn [t] x => x :: []
+}
+
+fun fromList [k ::: Type -> Type] [t ::: Type] (l : listLike k) (lst : list t) : k t =
+  l.FromList lst
+
+(* We shouldn't have to write this - there should be a generic "mappable" or
+"functor" with instances for option and list. *)
 con mappable k = t ::: Type -> u ::: Type -> (t -> u) -> k t -> k u
 fun mappable_option [t] [u] f x = Option.mp f x
 fun mappable_list [t] [u] f x = List.mp f x
+fun mappable_ident [t] [u] f x = f x
 
 fun createOptions [t ::: Type] (options : list (t * string * bool)) : xml [Cselect, Body] [] [] =
     List.mapXi (fn i (_, x, s) => <xml><coption value={show i} selected={s}>{[x]}</coption></xml>) options
@@ -58,7 +76,17 @@ fun createSingle [t] options selection =
       return {Options = createOptions options', Values = List.mp (fn x => x.1) options, Selected = s, Multi = False}
     end
 
-fun render [t] [k] (readFromList : singleOrMulti k) self = <xml>
+fun createRequiredSingle [t] options selection =
+    let
+      val selection' = min (max selection 0) (List.length options - 1)
+      val options' = List.mapi (fn i (v, x) => (v, x, Some i = selection')) options
+    in
+      s <- source selection';
+      return {Options = createOptions options', Values = List.mp (fn x => x.1) options, Selected = s, Multi = False}
+    end
+
+
+fun render [t] [k] (_ : listLike k) (mp : mappable k) self = <xml>
   <active code={id <- fresh;
                 return <xml>
                   <span onclick={fn _ => stopPropagation}>
@@ -66,8 +94,10 @@ fun render [t] [k] (readFromList : singleOrMulti k) self = <xml>
                       {self.Options}
                     </cselect>
                   </span>
-                  <active code={Select2Ffi.replace id (fn x => set self.Selected (readFromList x));
-                                return <xml></xml>}/>
+                  <active code={
+                    Select2Ffi.replace id
+                      (fn x => set self.Selected (mp readError (fromList x)));
+                    return <xml></xml>}/>
                 </xml>}/>
 </xml>
 

--- a/select2.ur
+++ b/select2.ur
@@ -24,6 +24,7 @@ fun singleOrMulti_option selections =
   | [] => None
 fun singleOrMulti_list selections = List.mp readError selections
 
+(* We shouldn't have to write this - there should be a generic "mappable" or "functor" with instances for option and list. *)
 con mappable k = t ::: Type -> u ::: Type -> (t -> u) -> k t -> k u
 fun mappable_option [t] [u] f x = Option.mp f x
 fun mappable_list [t] [u] f x = List.mp f x

--- a/select2.ur
+++ b/select2.ur
@@ -24,6 +24,10 @@ fun singleOrMulti_option selections =
   | [] => None
 fun singleOrMulti_list selections = List.mp readError selections
 
+con mappable k = t ::: Type -> u ::: Type -> (t -> u) -> k t -> k u
+fun mappable_option [t] [u] f x = Option.mp f x
+fun mappable_list [t] [u] f x = List.mp f x
+
 fun createOptions [t ::: Type] (options : list (t * string * bool)) : xml [Cselect, Body] [] [] =
     List.mapXi (fn i (_, x, s) => <xml><coption value={show i} selected={s}>{[x]}</coption></xml>) options
 
@@ -70,6 +74,6 @@ fun lookupValue [t ::: Type] (values : list t) (i : int) : t =
   (* This computation cannot fail since the `i` argument is guaranteed to be in-bounds. *)
   Option.unsafeGet (List.nth values i)
 
-fun selected [t] [k] (_ : monad k) self =
+fun selected [t] [k] (mp : mappable k) self =
   s <- signal self.Selected;
-  return (Monad.mp (lookupValue self.Values) s)
+  return (mp (lookupValue self.Values) s)

--- a/select2.urp
+++ b/select2.urp
@@ -4,4 +4,7 @@ clientOnly Select2Ffi.replace
 benignEffectful Select2Ffi.replace
 jsFile select2Urweb.js
 
+$/list
+$/option
+$/monad
 select2

--- a/select2.urp
+++ b/select2.urp
@@ -1,10 +1,14 @@
 ffi select2Ffi
 jsFunc Select2Ffi.replace=uw_select2_replace
+jsFunc Select2Ffi.setValues=uw_select2_set
 clientOnly Select2Ffi.replace
+clientOnly Select2Ffi.setValues
 benignEffectful Select2Ffi.replace
+benignEffectful Select2Ffi.setValues
 jsFile select2Urweb.js
 
 $/list
 $/option
 $/monad
+$/string
 select2

--- a/select2.urs
+++ b/select2.urs
@@ -4,9 +4,13 @@ class singleOrMulti :: (Type -> Type) -> Type
 val singleOrMulti_option : singleOrMulti option
 val singleOrMulti_list : singleOrMulti list
 
+class mappable :: (Type -> Type) -> Type
+val mappable_option : mappable option
+val mappable_list : mappable list
+
 val createMulti : t ::: Type -> list (t * string * bool) -> transaction (selector list t)
 val createSingle : t ::: Type -> list (t * string) -> option int -> transaction (selector option t)
 
 val render : t ::: Type -> k ::: (Type -> Type) -> singleOrMulti k -> selector k t -> xbody
 
-val selected : t ::: Type -> k ::: (Type -> Type) -> monad k -> selector k t -> signal (k t)
+val selected : t ::: Type -> k ::: (Type -> Type) -> mappable k -> selector k t -> signal (k t)

--- a/select2.urs
+++ b/select2.urs
@@ -14,6 +14,18 @@ val createMulti : t ::: Type -> list (t * string * bool) -> transaction (selecto
 val createSingle : t ::: Type -> list (t * string) -> option int -> transaction (selector option t)
 val createRequiredSingle : t ::: Type -> list (t * string) -> int -> transaction (selector ident t)
 
+val setSingleSelection : t ::: Type -> k ::: (Type -> Type) -> eq t ->
+  selector k t -> t -> transaction unit
+
+val setSingleSelection' : t ::: Type -> k ::: (Type -> Type) ->
+  selector k t -> int -> transaction unit
+
+val setMultiSelection : t ::: Type -> eq t ->
+  selector list t -> list t -> transaction unit
+
+val setMultiSelection' : t ::: Type ->
+  selector list t -> list int -> transaction unit
+
 val render : t ::: Type -> k ::: (Type -> Type) -> listLike k -> mappable k -> selector k t -> xbody
 
 val selected : t ::: Type -> k ::: (Type -> Type) -> mappable k -> selector k t -> signal (k t)

--- a/select2.urs
+++ b/select2.urs
@@ -14,6 +14,6 @@ val createMulti : t ::: Type -> list (t * string * bool) -> transaction (selecto
 val createSingle : t ::: Type -> list (t * string) -> option int -> transaction (selector option t)
 val createRequiredSingle : t ::: Type -> list (t * string) -> int -> transaction (selector ident t)
 
-val render : t ::: Type -> k ::: (Type -> Type) -> listLike k -> mappable k => selector k t -> xbody
+val render : t ::: Type -> k ::: (Type -> Type) -> listLike k -> mappable k -> selector k t -> xbody
 
 val selected : t ::: Type -> k ::: (Type -> Type) -> mappable k -> selector k t -> signal (k t)

--- a/select2.urs
+++ b/select2.urs
@@ -1,10 +1,12 @@
-type single
-type multi
-val createMulti : (* options: *) xml [Cselect, Body] [] [] -> transaction multi
-val createSingle (* only select one option *) : xml [Cselect, Body] [] [] -> transaction single
+con selector :: (Type -> Type) -> Type -> Type
 
-val renderMulti : multi -> xbody
-val renderSingle : single -> xbody
+class singleOrMulti :: (Type -> Type) -> Type
+val singleOrMulti_option : singleOrMulti option
+val singleOrMulti_list : singleOrMulti list
 
-val selectedMulti : multi -> signal (list string)
-val selectedSingle : single -> signal string
+val createMulti : t ::: Type -> list (t * string * bool) -> transaction (selector list t)
+val createSingle : t ::: Type -> list (t * string) -> option int -> transaction (selector option t)
+
+val render : t ::: Type -> k ::: (Type -> Type) -> singleOrMulti k -> selector k t -> xbody
+
+val selected : t ::: Type -> k ::: (Type -> Type) -> monad k -> selector k t -> signal (k t)

--- a/select2.urs
+++ b/select2.urs
@@ -1,5 +1,10 @@
-type t
-val create : (* options: *) xml [Cselect, Body] [] [] -> transaction t
-val createSingle (* only select one option *) : xml [Cselect, Body] [] [] -> transaction t
-val render : t -> xbody
-val selected : t -> signal (list string)
+type single
+type multi
+val createMulti : (* options: *) xml [Cselect, Body] [] [] -> transaction multi
+val createSingle (* only select one option *) : xml [Cselect, Body] [] [] -> transaction single
+
+val renderMulti : multi -> xbody
+val renderSingle : single -> xbody
+
+val selectedMulti : multi -> signal (list string)
+val selectedSingle : single -> signal string

--- a/select2.urs
+++ b/select2.urs
@@ -1,16 +1,19 @@
 con selector :: (Type -> Type) -> Type -> Type
 
-class singleOrMulti :: (Type -> Type) -> Type
-val singleOrMulti_option : singleOrMulti option
-val singleOrMulti_list : singleOrMulti list
+class listLike :: (Type -> Type) -> Type
+val listLike_option : listLike option
+val listLike_list : listLike list
+val listLike_ident : listLike ident
 
 class mappable :: (Type -> Type) -> Type
 val mappable_option : mappable option
 val mappable_list : mappable list
+val mappable_ident : mappable ident
 
 val createMulti : t ::: Type -> list (t * string * bool) -> transaction (selector list t)
 val createSingle : t ::: Type -> list (t * string) -> option int -> transaction (selector option t)
+val createRequiredSingle : t ::: Type -> list (t * string) -> int -> transaction (selector ident t)
 
-val render : t ::: Type -> k ::: (Type -> Type) -> singleOrMulti k -> selector k t -> xbody
+val render : t ::: Type -> k ::: (Type -> Type) -> listLike k -> mappable k => selector k t -> xbody
 
 val selected : t ::: Type -> k ::: (Type -> Type) -> mappable k -> selector k t -> signal (k t)

--- a/select2Ffi.urs
+++ b/select2Ffi.urs
@@ -1,1 +1,2 @@
 val replace : id -> (list string -> transaction unit) -> transaction unit
+val setValues : id -> list string -> transaction unit

--- a/select2Urweb.js
+++ b/select2Urweb.js
@@ -15,7 +15,14 @@ function uw_select2_replace(id, onChange) {
     var doChange = function() {
         execF(execF(onChange, arrayToUrweb($('#' + id).select2('data'))), null);
     };
-    
     $('#' + id).select2(settings).change(doChange);
     doChange();
+}
+
+function uw_select2_set(id, l) {
+  var lst = [];
+  for (; l; l = l._2)
+      lst.push(l._1);
+  $('#' + id).val(lst);
+  $('#' + id).trigger(`change`);
 }

--- a/select2Urweb.js
+++ b/select2Urweb.js
@@ -1,7 +1,7 @@
 function arrayToUrweb(arr) {
     var ls = null;
     for (var i = arr.length - 1; i >= 0; i--)
-        ls = {_1: arr[i].text, _2: ls};
+        ls = {_1: arr[i].id, _2: ls};
     return ls;
 }
 

--- a/smartTable.ur
+++ b/smartTable.ur
@@ -596,16 +596,12 @@ functor LinkedWithEdit(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                    if List.mem t lsV then
-                                                                        <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                    else
-                                                                        <xml><coption>{[t]}</coption></xml>) ts);
+                                s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
                                 return <xml>
-                                  {Select2.renderMulti s2}
-                                  <dyn signal={seled <- Select2.selectedMulti s2;
+                                  {Select2.render s2}
+                                  <dyn signal={seled <- Select2.selected s2;
                                                return <xml>
-                                                 <active code={set ls (List.mp readError seled);
+                                                 <active code={set ls seled;
                                                                return <xml></xml>}/>
                                                </xml>}/>
                                 </xml>}/>
@@ -649,13 +645,8 @@ functor LinkedWithEdit(M : sig
                                 Ui.modalIcon ctx
                                              (CLASS "glyphicon glyphicon-pencil-alt")
                                              (lsV <- get ls;
-                                              s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                        if List.mem t lsV then
-                                                                            <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                        else
-                                                                            <xml><coption>{[t]}</coption></xml>) ts);
-                                              return (Ui.modal (seled <- current (Select2.selectedMulti s2);
-                                                                seled <- return (List.mp readError seled);
+                                              s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
+                                              return (Ui.modal (seled <- current (Select2.selected s2);
                                                                 List.app (fn selectedNow =>
                                                                              if List.mem selectedNow lsV then
                                                                                  return ()
@@ -668,7 +659,7 @@ functor LinkedWithEdit(M : sig
                                                                                  rpc (remove k selectedBefore)) lsV;
                                                                 set ls seled)
                                                                <xml>Change selection</xml>
-                                                               (Select2.renderMulti s2)
+                                                               (Select2.render s2)
                                                                <xml>Save</xml>))}
                      </td></xml>
                  end,
@@ -800,16 +791,12 @@ functor LinkedWithEditForOwner(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                    if List.mem t lsV then
-                                                                        <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                    else
-                                                                        <xml><coption>{[t]}</coption></xml>) ts);
+                                s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
                                 return <xml>
-                                  {Select2.renderMulti s2}
-                                  <dyn signal={seled <- Select2.selectedMulti s2;
+                                  {Select2.render s2}
+                                  <dyn signal={seled <- Select2.selected s2;
                                                return <xml>
-                                                 <active code={set ls (List.mp readError seled);
+                                                 <active code={set ls seled;
                                                                return <xml></xml>}/>
                                                </xml>}/>
                                 </xml>}/>
@@ -857,13 +844,8 @@ functor LinkedWithEditForOwner(M : sig
                                     Ui.modalIcon ctx
                                                  (CLASS "glyphicon glyphicon-pencil-alt")
                                                  (lsV <- get ls;
-                                                  s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                            if List.mem t lsV then
-                                                                                <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                            else
-                                                                                <xml><coption>{[t]}</coption></xml>) ts);
-                                                  return (Ui.modal (seled <- current (Select2.selectedMulti s2);
-                                                                    seled <- return (List.mp readError seled);
+                                                  s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
+                                                  return (Ui.modal (seled <- current (Select2.selected s2);
                                                                     List.app (fn selectedNow =>
                                                                                  if List.mem selectedNow lsV then
                                                                                      return ()
@@ -876,7 +858,7 @@ functor LinkedWithEditForOwner(M : sig
                                                                                      rpc (remove k selectedBefore)) lsV;
                                                                     set ls seled)
                                                                    <xml>Change selection</xml>
-                                                                   (Select2.renderMulti s2)
+                                                                   (Select2.render s2)
                                                                    <xml>Save</xml>))}
                      </td></xml>
                  end,
@@ -992,16 +974,12 @@ functor LinkedWithEditAndDefault(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                    if List.mem t lsV then
-                                                                        <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                    else
-                                                                        <xml><coption>{[t]}</coption></xml>) ts);
+                                s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
                                 return <xml>
-                                  {Select2.renderMulti s2}
-                                  <dyn signal={seled <- Select2.selectedMulti s2;
+                                  {Select2.render s2}
+                                  <dyn signal={seled <- Select2.selected s2;
                                                return <xml>
-                                                 <active code={set ls (List.mp readError seled);
+                                                 <active code={set ls seled;
                                                                return <xml></xml>}/>
                                                </xml>}/>
                                 </xml>}/>
@@ -1045,13 +1023,8 @@ functor LinkedWithEditAndDefault(M : sig
                                 Ui.modalIcon ctx
                                              (CLASS "glyphicon glyphicon-pencil-alt")
                                              (lsV <- get ls;
-                                              s2 <- Select2.createMulti (List.mapX (fn t =>
-                                                                        if List.mem t lsV then
-                                                                            <xml><coption selected={True}>{[t]}</coption></xml>
-                                                                        else
-                                                                            <xml><coption>{[t]}</coption></xml>) ts);
-                                              return (Ui.modal (seled <- current (Select2.selectedMulti s2);
-                                                                seled <- return (List.mp readError seled);
+                                              s2 <- Select2.createMulti (List.mp (fn t => (t, show t, List.mem t lsV)) ts);
+                                              return (Ui.modal (seled <- current (Select2.selected s2);
                                                                 List.app (fn selectedNow =>
                                                                              if List.mem selectedNow lsV then
                                                                                  return ()
@@ -1064,7 +1037,7 @@ functor LinkedWithEditAndDefault(M : sig
                                                                                  rpc (remove k selectedBefore)) lsV;
                                                                 set ls seled)
                                                                <xml>Change selection</xml>
-                                                               (Select2.renderMulti s2)
+                                                               (Select2.render s2)
                                                                <xml>Save</xml>))}
                      </td></xml>
                  end,

--- a/smartTable.ur
+++ b/smartTable.ur
@@ -596,14 +596,14 @@ functor LinkedWithEdit(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.create (List.mapX (fn t =>
+                                s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                     if List.mem t lsV then
                                                                         <xml><coption selected={True}>{[t]}</coption></xml>
                                                                     else
                                                                         <xml><coption>{[t]}</coption></xml>) ts);
                                 return <xml>
-                                  {Select2.render s2}
-                                  <dyn signal={seled <- Select2.selected s2;
+                                  {Select2.renderMulti s2}
+                                  <dyn signal={seled <- Select2.selectedMulti s2;
                                                return <xml>
                                                  <active code={set ls (List.mp readError seled);
                                                                return <xml></xml>}/>
@@ -649,12 +649,12 @@ functor LinkedWithEdit(M : sig
                                 Ui.modalIcon ctx
                                              (CLASS "glyphicon glyphicon-pencil-alt")
                                              (lsV <- get ls;
-                                              s2 <- Select2.create (List.mapX (fn t =>
+                                              s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                         if List.mem t lsV then
                                                                             <xml><coption selected={True}>{[t]}</coption></xml>
                                                                         else
                                                                             <xml><coption>{[t]}</coption></xml>) ts);
-                                              return (Ui.modal (seled <- current (Select2.selected s2);
+                                              return (Ui.modal (seled <- current (Select2.selectedMulti s2);
                                                                 seled <- return (List.mp readError seled);
                                                                 List.app (fn selectedNow =>
                                                                              if List.mem selectedNow lsV then
@@ -668,7 +668,7 @@ functor LinkedWithEdit(M : sig
                                                                                  rpc (remove k selectedBefore)) lsV;
                                                                 set ls seled)
                                                                <xml>Change selection</xml>
-                                                               (Select2.render s2)
+                                                               (Select2.renderMulti s2)
                                                                <xml>Save</xml>))}
                      </td></xml>
                  end,
@@ -800,14 +800,14 @@ functor LinkedWithEditForOwner(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.create (List.mapX (fn t =>
+                                s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                     if List.mem t lsV then
                                                                         <xml><coption selected={True}>{[t]}</coption></xml>
                                                                     else
                                                                         <xml><coption>{[t]}</coption></xml>) ts);
                                 return <xml>
-                                  {Select2.render s2}
-                                  <dyn signal={seled <- Select2.selected s2;
+                                  {Select2.renderMulti s2}
+                                  <dyn signal={seled <- Select2.selectedMulti s2;
                                                return <xml>
                                                  <active code={set ls (List.mp readError seled);
                                                                return <xml></xml>}/>
@@ -857,12 +857,12 @@ functor LinkedWithEditForOwner(M : sig
                                     Ui.modalIcon ctx
                                                  (CLASS "glyphicon glyphicon-pencil-alt")
                                                  (lsV <- get ls;
-                                                  s2 <- Select2.create (List.mapX (fn t =>
+                                                  s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                             if List.mem t lsV then
                                                                                 <xml><coption selected={True}>{[t]}</coption></xml>
                                                                             else
                                                                                 <xml><coption>{[t]}</coption></xml>) ts);
-                                                  return (Ui.modal (seled <- current (Select2.selected s2);
+                                                  return (Ui.modal (seled <- current (Select2.selectedMulti s2);
                                                                     seled <- return (List.mp readError seled);
                                                                     List.app (fn selectedNow =>
                                                                                  if List.mem selectedNow lsV then
@@ -876,7 +876,7 @@ functor LinkedWithEditForOwner(M : sig
                                                                                      rpc (remove k selectedBefore)) lsV;
                                                                     set ls seled)
                                                                    <xml>Change selection</xml>
-                                                                   (Select2.render s2)
+                                                                   (Select2.renderMulti s2)
                                                                    <xml>Save</xml>))}
                      </td></xml>
                  end,
@@ -992,14 +992,14 @@ functor LinkedWithEditAndDefault(M : sig
                 <div class="form-group">
                   <label class="control-label">{[savedLabel]}</label>
                   <active code={lsV <- get ls;
-                                s2 <- Select2.create (List.mapX (fn t =>
+                                s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                     if List.mem t lsV then
                                                                         <xml><coption selected={True}>{[t]}</coption></xml>
                                                                     else
                                                                         <xml><coption>{[t]}</coption></xml>) ts);
                                 return <xml>
-                                  {Select2.render s2}
-                                  <dyn signal={seled <- Select2.selected s2;
+                                  {Select2.renderMulti s2}
+                                  <dyn signal={seled <- Select2.selectedMulti s2;
                                                return <xml>
                                                  <active code={set ls (List.mp readError seled);
                                                                return <xml></xml>}/>
@@ -1045,12 +1045,12 @@ functor LinkedWithEditAndDefault(M : sig
                                 Ui.modalIcon ctx
                                              (CLASS "glyphicon glyphicon-pencil-alt")
                                              (lsV <- get ls;
-                                              s2 <- Select2.create (List.mapX (fn t =>
+                                              s2 <- Select2.createMulti (List.mapX (fn t =>
                                                                         if List.mem t lsV then
                                                                             <xml><coption selected={True}>{[t]}</coption></xml>
                                                                         else
                                                                             <xml><coption>{[t]}</coption></xml>) ts);
-                                              return (Ui.modal (seled <- current (Select2.selected s2);
+                                              return (Ui.modal (seled <- current (Select2.selectedMulti s2);
                                                                 seled <- return (List.mp readError seled);
                                                                 List.app (fn selectedNow =>
                                                                              if List.mem selectedNow lsV then
@@ -1064,7 +1064,7 @@ functor LinkedWithEditAndDefault(M : sig
                                                                                  rpc (remove k selectedBefore)) lsV;
                                                                 set ls seled)
                                                                <xml>Change selection</xml>
-                                                               (Select2.render s2)
+                                                               (Select2.renderMulti s2)
                                                                <xml>Save</xml>))}
                      </td></xml>
                  end,


### PR DESCRIPTION
[Issue page](https://github.com/nectry/nectry/issues/71)

## Changes
* Select2 module now has two types: single and multi, corresponding to selection dropdowns where only one option can be selected and where multiple options can be selected.
* Updated smartTable since it uses Select2
  * See PR in nectry repo for changes to other places where this module is used.
* Created example of Select2 usage. This could probably be cleaned up a bit.

## Remaining work on this issue
* implement setSelectionSingle and setSelectionMulti
* Decide whether we want some notion of an optional or default selection in the single case. Since multi corresponds to a list of strings, it is easy for the programmer using this module to write a case handling when nothing is selected. But selectedSingle always produces a string, so there is not an obvious, idiomatic, nicely-typed way to provide a default value or behavior when the user has not selected any option. The best way around this right now is to add a default option to the selection and make it pre-selected.